### PR TITLE
Remove duplicated retry handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/namgk/node-red-contrib-ros#readme",
   "dependencies": {
-    "roslib": "^0.18.0"
+    "roslib": "^1.0.1"
   }
 }

--- a/ros-server-node.js
+++ b/ros-server-node.js
@@ -14,8 +14,6 @@ module.exports = function (RED){
       }
     });
 
-    var trials = 0;
-
     function startconn() {    // Connect to remote endpoint
       var ros = new ROSLIB.Ros({
         url : config.url
@@ -31,13 +29,8 @@ module.exports = function (RED){
       });
 
       ros.on('error', function(error) {
-        trials++;
       	node.emit('ros error');
         node.log('Error connecting : ', error);
-        if (!node.closing) {
-          node.log('reconnecting');
-          node.tout = setTimeout(function(){ startconn(); }, Math.pow(2, trials) * 1000);
-        }
       });
 
       ros.on('close', function() {


### PR DESCRIPTION
In the current implementation, Node-RED seems to crash when the node retries connections because of huge memory usage. The problem occurs from duplicated retry handling (When the node is disconnected, both `error` and `close` events occurred and both handlings try to make a connection again). Because single handling is enough for retrying, I removed the handling in the `error` event.